### PR TITLE
✨Amazon Primeの時間同期実装（広告も対応）

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,14 +2,15 @@
     "manifest_version": 3,
     "name": "AdjusTimer",
     "description": "再生動画の再生時間を別ウィンドウで映す拡張",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "content_scripts": [
       {
         "js": ["src/content/index.tsx"],
         "run_at": "document_idle",
         "matches": [
           "https://anime.dmkt-sp.jp/*",
-          "https://animestore.docomo.ne.jp/*"
+          "https://animestore.docomo.ne.jp/*",
+          "https://www.amazon.co.jp/gp/video/*"
         ]
       }
     ],

--- a/src/background/features/AdjusTimerWindow.tsx
+++ b/src/background/features/AdjusTimerWindow.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useEffect } from "react";
 import Timer from "./Timer/Timer";
 
 import "../../style.css";
@@ -81,7 +81,7 @@ export const AdjusTimerWindow = (): ReactElement => {
     }
 
     return (
-        <div className="flex flex-col h-screen">
+        <div className="flex flex-col h-screen overflow-scroll hidden-scrollbar">
             <Timer />
             <Menu />
         </div>

--- a/src/background/features/AdjusTimerWindow.tsx
+++ b/src/background/features/AdjusTimerWindow.tsx
@@ -70,7 +70,8 @@ export const AdjusTimerWindow = (): ReactElement => {
                     url: response.url,
                     currentTime: response.currentTime,
                     pageType: response.pageType,
-                    tabTitle: response.tabTitle
+                    isAdBreak: response.isAdBreak,
+                    adBreakRemainTime: response.adBreakRemainTime,
                 }
                 setCurrentVideo(updateVideoState);
                 break;

--- a/src/background/features/Timer/Timer.tsx
+++ b/src/background/features/Timer/Timer.tsx
@@ -20,6 +20,32 @@ const Timer = () => {
                 color: textColor ? textColor : DEFAULT_TEXT_COLOR
             }}
         >
+            {currentVideo.isAdBreak && (
+                <div>
+                    <span className="
+                        py-1
+                        px-1.5
+                        inline-flex
+                        items-center
+                        gap-x-1
+                        text-xs
+                        font-medium
+                        bg-red-100
+                        text-red-800
+                        rounded-full
+                        dark:bg-red-500/10
+                        dark:text-red-500
+                    ">
+                        <svg className="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path>
+                            <path d="M12 9v4"></path>
+                            <path d="M12 17h.01"></path>
+                        </svg>
+                        広告再生中 - 残り:{currentVideo.adBreakRemainTime}
+                    </span>
+                </div>
+            )}
+
             <p className="text-4xl">{currentVideo.title}</p>
             <p className="text-3xl">{currentVideo.subTitle}</p>
             <p className="mt-10 text-6xl">{currentVideo.currentTime}</p>

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -77,7 +77,9 @@ const onConnectContentScript = (message: any, sender: any, sendResponse: any) =>
                 subTitle: message.subTitle,
                 url: message.url,
                 currentTime: message.currentTime,
-                pageType: message.pageType
+                pageType: message.pageType,
+                isAdBreak: message.isAdBreak,
+                adBreakRemainTime: message.adBreakRemainTime,
             });
             break;
         default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,12 +4,15 @@ export interface VideoState {
     currentTime: string,
     url: string,
     pageType: string,
-    tabTitle: string,
+    isAdBreak: boolean,
+    adBreakRemainTime: string,
 }
 
 export interface updateVideoPayload {
     currentLocation: Location,
-    currentTime: number | undefined
+    currentTime: number | undefined,
+    isAdBreak: boolean,
+    adBreakRemainTime: string,
 }
 
 export class TabInfo {
@@ -28,13 +31,16 @@ export const ADJUSTIMER_WINDOW_UPDATE = "update_adjustimer";
 export const ADJUSTIMER_WINDOW_TYPE_CHECK = "check_service_worker";
 
 export const VIDEO_NAME_DANIME = 'dAnime';
+export const VIDEO_NAME_AMAZON_PRIME = 'AmazonPrime';
 export const URL_TYPE_NOT_FOUND: string = 'notFound';
+export const TITLE_NOT_FOUND = "動画の更新等をお試しください。";
 
 export const MODE_CREATE_WINDOW: string = 'CREATE_WINDOW';
 export const MODE_RELOAD_WINDOW: string = 'MODE_RELOAD_WINDOW';
 export const MODE_UPDATE_TO_CONTENT_SCRIPT: string = 'MODE_UPDATE_TO_CONTENT_SCRIPT';
 
 export const REGEX_URL_DANIME = new RegExp("https://animestore.docomo.ne.jp/animestore/sc_d_pc=*");
+export const REGEX_URL_AMAZON_PRIME = new RegExp("https://www.amazon.co.jp/gp/video/*");
 
 export const STORAGE_KEY_BACKGROUND_COLOR = "AdjusTimer_backgroundColor";
 export const STORAGE_KEY_TEXT_COLOR = "AdjusTimer_textColor";
@@ -47,6 +53,7 @@ export const isTargetUrl = (url: string | undefined) => {
     let isSuccess: boolean = false;
     switch(true) {
         case REGEX_URL_DANIME.test(url):
+        case REGEX_URL_AMAZON_PRIME.test(url):
             isSuccess = true;
             break;
         default:
@@ -64,3 +71,25 @@ export const secondToTimeString = (sec: number) => {
     const result = `${pad(m)}:${pad(s)}`;
     return `${pad(h)}:${result}`;
 };
+
+/**
+ * "hh:mm:ss" 形式の文字列を秒数に変換する
+ * @param {string} timeStr - "xx:yy:zz" 形式の文字列
+ * @returns {number} 秒数
+ */
+export const timeStringToSeconds = (timeStr: string) => {
+  const parts = timeStr.split(":").map(Number);
+
+  // 桁数に応じて計算 (例: "mm:ss", "hh:mm:ss" 両対応)
+  if (parts.length === 3) {
+    const [hh, mm, ss] = parts;
+    return hh * 3600 + mm * 60 + ss;
+  } else if (parts.length === 2) {
+    const [mm, ss] = parts;
+    return mm * 60 + ss;
+  } else if (parts.length === 1) {
+    return parts[0]; // 秒だけ
+  } else {
+    throw new Error("Invalid time format: " + timeStr);
+  }
+}

--- a/src/content/atom.ts
+++ b/src/content/atom.ts
@@ -1,20 +1,24 @@
 import { atom } from "jotai";
 import {
+    REGEX_URL_AMAZON_PRIME,
     REGEX_URL_DANIME,
     secondToTimeString,
+    TITLE_NOT_FOUND,
     updateVideoPayload,
     URL_TYPE_NOT_FOUND,
+    VIDEO_NAME_AMAZON_PRIME,
     VIDEO_NAME_DANIME,
     VideoState
 } from "../constants";
 
 export const initialVideoState: VideoState = {
-    title: '「情報を更新」か、ページを更新してAdjusTimerを再起動をしてください.',
+    title: '動画ページを開いてください。',
     subTitle: '',
     currentTime: '00:00:00',
     url: '',
     pageType: URL_TYPE_NOT_FOUND,
-    tabTitle: '',
+    isAdBreak: false,
+    adBreakRemainTime: "0:00"
 }
 
 export const currentUrl = atom<string>();
@@ -38,17 +42,29 @@ export const getVideo = atom(
                 targetVideoSubTitle = `${epNum} ${epTitle}`
                 newVideo.pageType = VIDEO_NAME_DANIME;
                 break;
+            case REGEX_URL_AMAZON_PRIME.test(update.currentLocation.href):
+                targetVideoTitle = document.querySelector(".dv-player-fullscreen .atvwebplayersdk-title-text")
+                                    ? document.querySelector(".dv-player-fullscreen .atvwebplayersdk-title-text")?.textContent
+                                    : TITLE_NOT_FOUND
+                targetVideoSubTitle = document.querySelector(".dv-player-fullscreen .atvwebplayersdk-subtitle-text")
+                                    ? document.querySelector(".dv-player-fullscreen .atvwebplayersdk-subtitle-text")?.textContent
+                                    : ""
+                newVideo.pageType = VIDEO_NAME_AMAZON_PRIME;
+                break;
             default:
-                targetVideoTitle = '未取得';
+                targetVideoTitle = TITLE_NOT_FOUND;
                 break;
         }
         newVideo.title = targetVideoTitle;
         newVideo.subTitle = targetVideoSubTitle;
         newVideo.url = update.currentLocation.href;
-        newVideo.currentTime = secondToTimeString(
-            update.currentTime ? update.currentTime : 0
-        );
-        newVideo.tabTitle = document.title;
+        if (!update.isAdBreak) {
+            newVideo.currentTime = secondToTimeString(
+                update.currentTime ? update.currentTime : 0
+            );
+        }
+        newVideo.isAdBreak = update.isAdBreak;
+        newVideo.adBreakRemainTime = update.adBreakRemainTime;
 
         set(videoAtom, newVideo);
     },

--- a/src/content/features/VideoInfo.tsx
+++ b/src/content/features/VideoInfo.tsx
@@ -69,11 +69,13 @@ const VideoInfo = (): ReactElement => {
                 if (!adDom) {
                     const primeVideo = document.getElementsByClassName("atvwebplayersdk-timeindicator-text")
                     if (primeVideo.length > 0) {
-                        const playShowTime = document.getElementsByClassName("atvwebplayersdk-timeindicator-text")[0].textContent;
-                        updateTime = timeStringToSeconds(playShowTime.split("/")[0].trim());
+                        const playShowTime: string | null = document.getElementsByClassName("atvwebplayersdk-timeindicator-text")[0].textContent;
+                        if (playShowTime) {
+                            updateTime = timeStringToSeconds(playShowTime.split("/")[0].trim());
+                        }
                     }
                 } else {
-                    adBreakRemainTime = adDom?.textContent;
+                    adBreakRemainTime = adDom.textContent ? adDom.textContent : "";
                     isAdBreak = true;
                 }
                 break;

--- a/src/content/hooks.ts
+++ b/src/content/hooks.ts
@@ -16,12 +16,11 @@ export const useMutationObserver = (
     }
 ) => {
     useEffect(() => {
-        // DOMが見つかるまで探す
-
-        if (elements) {
-            const observer = new MutationObserver(callback);
-            return () => observer.disconnect();
-        }
+        if (!elements) return;
+        console.log("Content Script: start observe.");
+        const observer = new MutationObserver(callback);
+        observer.observe(elements, options);
+        return () => observer.disconnect();
     }, []);
 };
   

--- a/src/style.css
+++ b/src/style.css
@@ -1,1 +1,12 @@
 @import "tailwindcss";
+
+@layer utilities {
+    .hidden-scrollbar {
+        -ms-overflow-style: none; /* IE, Edge 対応 */
+        scrollbar-width: none; /* Firefox 対応 */
+    }
+    .hidden-scrollbar::-webkit-scrollbar {
+        /* Chrome, Safari 対応 */
+        display: none;
+    }
+}


### PR DESCRIPTION
# Amazon Primeの動画実装

- 広告用の判定を追加（isAdBreak）
- Amazon Primeでの時間取得追加
- URLの変更検知のobserverを実装（SPAのページへの対処）

timeupdateによる更新を共通化させたいため、Amazon Primeのvideo要素（広告との合算値）のtimeupdateを走らせながら、表示されているDOMの再生時間を取得する方法をとった
（少なくとも、video要素の再生時間 ≧ DOMの再生時間 となるため）

# テスト

https://docs.google.com/document/d/187iUdAb-v-3n9MM7Ui497x9EgN3WMhDiQSpK4hBEUyc/edit?tab=t.0
