### PR TITLE
✨Tver/Netflix/ニコニコ動画対応、広告部分の判定修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
           "https://animestore.docomo.ne.jp/*",
           "https://www.amazon.co.jp/gp/video/*",
           "https://www.youtube.com/*",
+          "https://tver.jp/*",
           "https://www.nicovideo.jp/watch/*"
         ]
       }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "AdjusTimer",
     "description": "再生動画の再生時間を別ウィンドウで映す拡張",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "content_scripts": [
       {
         "js": ["src/content/index.tsx"],
@@ -11,7 +11,8 @@
           "https://anime.dmkt-sp.jp/*",
           "https://animestore.docomo.ne.jp/*",
           "https://www.amazon.co.jp/gp/video/*",
-          "https://www.youtube.com/*"
+          "https://www.youtube.com/*",
+          "https://www.nicovideo.jp/watch/*"
         ]
       }
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
           "https://www.amazon.co.jp/gp/video/*",
           "https://www.youtube.com/*",
           "https://tver.jp/*",
-          "https://www.nicovideo.jp/watch/*"
+          "https://www.nicovideo.jp/watch/*",
+          "https://www.netflix.com/*"
         ]
       }
     ],
@@ -29,5 +30,15 @@
       "48": "extension_48.png",
       "128": "extension_128.png"
     },
-    "permissions": ["contextMenus", "tabs", "storage"]
+    "permissions": ["contextMenus", "tabs", "storage"],
+    "web_accessible_resources": [
+      {
+        "resources": [
+          "adjustimer-netflix-loader.js"
+        ],
+        "matches": [
+          "https://www.netflix.com/*"
+        ]
+      }
+    ]
 }

--- a/public/adjustimer-netflix-loader.js
+++ b/public/adjustimer-netflix-loader.js
@@ -1,0 +1,69 @@
+console.log("Content Script: inject script Netflix");
+let tabTitle = "";
+
+const setNetflixTitle = () => {
+  console.log("Content Script: find Netfilix title...");
+  // タイトル取得
+  let checkNetflix = setInterval(() => {
+    const videoId = location.href.split("?")[0].split("/").slice(-1)[0];
+    const currentTitle = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.title;
+    const currentEpisodeId = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.currentEpisode;
+
+    if (currentTitle) {
+      let adjusTimerTitle = `${currentTitle}`;
+      let adjusTimerSubTitle = "";
+      if (currentEpisodeId) {
+        let currentEpisodeIndex;
+        if (window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.seasons.length > 0) {
+          const currentSeason = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video.seasons.filter(season => {
+            const episodeIndex = season.episodes.findIndex(episode => episode.episodeId === currentEpisodeId);
+            if (episodeIndex !== -1) {
+              currentEpisodeIndex = episodeIndex;
+              return season;
+            }
+          })
+          if (currentSeason) {
+            adjusTimerSubTitle = ` シーズン${currentSeason[0].seq}-${currentSeason[0]?.episodes[currentEpisodeIndex]?.seq} ${currentSeason[0]?.episodes[currentEpisodeIndex]?.title}`
+          }
+        }
+      }
+
+      if (tabTitle != `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`) {
+        document.title = `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`;
+        tabTitle = `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`;
+      }
+      const currentTimeObject = Object.entries(window.netflix.appContext.state.playerApp.getState().videoPlayer.playbackStateBySessionId)
+                        .filter(([key, value]) => key.includes("watch"))
+                        .map(([key, value]) => value.currentTime)[0];
+      const currentTime = currentTimeObject ? currentTimeObject / 1000 : 0;
+
+      if (document.querySelector(".netflixTitle")) {
+        document.querySelector(".netflixTitle").textContent = adjusTimerTitle;
+        document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
+        document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
+        document.querySelector(".netflixCurrentTime").textContent = currentTime;
+      } else {
+        // DOMに反映
+        const titleNameElement = document.createElement("p");
+        titleNameElement.style.display = "none";
+        titleNameElement.className = "netflixTitle";
+        titleNameElement.textContent = adjusTimerTitle;
+        document.body.appendChild(titleNameElement);
+        
+        const subTitleNameElement = document.createElement("p");
+        subTitleNameElement.style.display = "none";
+        subTitleNameElement.className = "netflixSubTitle";
+        subTitleNameElement.textContent = adjusTimerSubTitle;
+        document.body.appendChild(subTitleNameElement);
+
+        const currentTimeElement = document.createElement("p");
+        currentTimeElement.style.display = "none";
+        currentTimeElement.className = "netflixCurrentTime";
+        currentTimeElement.textContent = currentTime;
+        document.body.appendChild(currentTimeElement);
+      }
+    }
+  }, 800)
+}
+
+setNetflixTitle();

--- a/public/adjustimer-netflix-loader.js
+++ b/public/adjustimer-netflix-loader.js
@@ -1,69 +1,72 @@
 console.log("Content Script: inject script Netflix");
 let tabTitle = "";
 
-const setNetflixTitle = () => {
+const setNetflixTitleAndTime = () => {
   console.log("Content Script: find Netfilix title...");
   // タイトル取得
-  let checkNetflix = setInterval(() => {
-    const videoId = location.href.split("?")[0].split("/").slice(-1)[0];
-    const currentTitle = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.title;
-    const currentEpisodeId = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.currentEpisode;
+  const videoId = location.href.split("?")[0].split("/").slice(-1)[0];
+  const currentTitle = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.title;
+  const currentEpisodeId = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.currentEpisode;
 
-    if (currentTitle) {
-      let adjusTimerTitle = `${currentTitle}`;
-      let adjusTimerSubTitle = "";
-      if (currentEpisodeId) {
-        let currentEpisodeIndex;
-        if (window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.seasons.length > 0) {
-          const currentSeason = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video.seasons.filter(season => {
-            const episodeIndex = season.episodes.findIndex(episode => episode.episodeId === currentEpisodeId);
-            if (episodeIndex !== -1) {
-              currentEpisodeIndex = episodeIndex;
-              return season;
-            }
-          })
-          if (currentSeason) {
-            adjusTimerSubTitle = ` シーズン${currentSeason[0].seq}-${currentSeason[0]?.episodes[currentEpisodeIndex]?.seq} ${currentSeason[0]?.episodes[currentEpisodeIndex]?.title}`
+  if (currentTitle) {
+    let adjusTimerTitle = `${currentTitle}`;
+    let adjusTimerSubTitle = "";
+    if (currentEpisodeId) {
+      let currentEpisodeIndex;
+      if (window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.seasons.length > 0) {
+        const currentSeason = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video.seasons.filter(season => {
+          const episodeIndex = season.episodes.findIndex(episode => episode.episodeId === currentEpisodeId);
+          if (episodeIndex !== -1) {
+            currentEpisodeIndex = episodeIndex;
+            return season;
           }
+        })
+        if (currentSeason) {
+          adjusTimerSubTitle = ` シーズン${currentSeason[0].seq}-${currentSeason[0]?.episodes[currentEpisodeIndex]?.seq} ${currentSeason[0]?.episodes[currentEpisodeIndex]?.title}`
         }
       }
-
-      if (tabTitle != `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`) {
-        document.title = `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`;
-        tabTitle = `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`;
-      }
-      const currentTimeObject = Object.entries(window.netflix.appContext.state.playerApp.getState().videoPlayer.playbackStateBySessionId)
-                        .filter(([key, value]) => key.includes("watch"))
-                        .map(([key, value]) => value.currentTime)[0];
-      const currentTime = currentTimeObject ? currentTimeObject / 1000 : 0;
-
-      if (document.querySelector(".netflixTitle")) {
-        document.querySelector(".netflixTitle").textContent = adjusTimerTitle;
-        document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
-        document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
-        document.querySelector(".netflixCurrentTime").textContent = currentTime;
-      } else {
-        // DOMに反映
-        const titleNameElement = document.createElement("p");
-        titleNameElement.style.display = "none";
-        titleNameElement.className = "netflixTitle";
-        titleNameElement.textContent = adjusTimerTitle;
-        document.body.appendChild(titleNameElement);
-        
-        const subTitleNameElement = document.createElement("p");
-        subTitleNameElement.style.display = "none";
-        subTitleNameElement.className = "netflixSubTitle";
-        subTitleNameElement.textContent = adjusTimerSubTitle;
-        document.body.appendChild(subTitleNameElement);
-
-        const currentTimeElement = document.createElement("p");
-        currentTimeElement.style.display = "none";
-        currentTimeElement.className = "netflixCurrentTime";
-        currentTimeElement.textContent = currentTime;
-        document.body.appendChild(currentTimeElement);
-      }
     }
-  }, 800)
+
+    if (tabTitle != `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`) {
+      document.title = `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`;
+      tabTitle = `${adjusTimerTitle} | ${adjusTimerSubTitle} - Netflix`;
+    }
+    const currentTimeObject = Object.entries(window.netflix.appContext.state.playerApp.getState().videoPlayer.playbackStateBySessionId)
+                      .filter(([key, value]) => key.includes("watch"))
+                      .map(([key, value]) => value.currentTime)[0];
+    const currentTime = currentTimeObject ? currentTimeObject / 1000 : 0;
+
+    if (document.querySelector(".netflixTitle")) {
+      document.querySelector(".netflixTitle").textContent = adjusTimerTitle;
+      document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
+      document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
+      document.querySelector(".netflixCurrentTime").textContent = currentTime;
+    } else {
+      // DOMに反映
+      const titleNameElement = document.createElement("p");
+      titleNameElement.style.display = "none";
+      titleNameElement.className = "netflixTitle";
+      titleNameElement.textContent = adjusTimerTitle;
+      document.body.appendChild(titleNameElement);
+
+      const subTitleNameElement = document.createElement("p");
+      subTitleNameElement.style.display = "none";
+      subTitleNameElement.className = "netflixSubTitle";
+      subTitleNameElement.textContent = adjusTimerSubTitle;
+      document.body.appendChild(subTitleNameElement);
+
+      const currentTimeElement = document.createElement("p");
+      currentTimeElement.style.display = "none";
+      currentTimeElement.className = "netflixCurrentTime";
+      currentTimeElement.textContent = currentTime;
+      document.body.appendChild(currentTimeElement);
+    }
+  }
 }
 
-setNetflixTitle();
+let checkVideoDOM = setInterval(() => {
+  if (document.querySelector("video")) {
+    document.querySelector("video").addEventListener("timeupdate", setNetflixTitleAndTime);
+    clearInterval(checkVideoDOM);
+  }
+}, 500);

--- a/src/background/atom.ts
+++ b/src/background/atom.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import { STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_TEXT_COLOR, VideoState } from "../constants";
+import { CUSTOM_FONTS, DEFAULT_FONT_WEIGHTS, DEFAULT_TEXT_COLOR, STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_FONT_WEIGHT, STORAGE_KEY_FONTFAMILIY, STORAGE_KEY_IS_SHOW_DATE, STORAGE_KEY_SHADOW_COLOR, STORAGE_KEY_SHADOW_SIZE, STORAGE_KEY_TEXT_COLOR, VideoState } from "../constants";
 import { initialVideoState } from "../content/atom";
 
 export const backgroundColor = atom<string>();
@@ -11,6 +11,12 @@ export const pipWindow = atom<Window | null>(null);
 export const isPipWindowSupported = atom<boolean>("documentPictureInPicture" in window);
 
 export const port = atom<any>();
+export const customFont = atom<string>(CUSTOM_FONTS[0]);
+export const shadowSize = atom<number>(0);
+export const shadowColor = atom<string>(DEFAULT_TEXT_COLOR);
+export const fontWeight = atom<number>(5);
+export const currentDate = atom<Date>(new Date());
+export const showCurrentDate = atom<boolean>(true);
 
 export const getBackgroundColor = atom(
     (get) => get(backgroundColor),
@@ -50,5 +56,62 @@ export const getPipWindow = atom(
     (get) => get(pipWindow),
     (get, set, update: Window | null) => {
         set(pipWindow, update);
+    }
+)
+
+export const getCustomFont = atom(
+    (get) => get(customFont),
+    (get, set, newFont: string | null) => {
+        chrome.storage.local.set({[STORAGE_KEY_FONTFAMILIY]: newFont})
+            .then(() => {
+                set(customFont, newFont ? newFont : CUSTOM_FONTS[0]);
+            });
+    }
+)
+
+export const getShadowSize = atom(
+    (get) => get(shadowSize),
+    (get, set, newShadowSize: number | null) => {
+        chrome.storage.local.set({[STORAGE_KEY_SHADOW_SIZE]: newShadowSize})
+            .then(() => {
+                set(shadowSize, newShadowSize ? newShadowSize : 0);
+            });
+    }
+)
+
+export const getShadowColor = atom(
+    (get) => get(shadowColor),
+    (get, set, newShadowColor: string | null) => {
+        chrome.storage.local.set({[STORAGE_KEY_SHADOW_COLOR]: newShadowColor})
+            .then(() => {
+                set(shadowColor, newShadowColor ? newShadowColor : DEFAULT_TEXT_COLOR);
+            });
+    }
+)
+
+export const getFontWeight = atom(
+    (get) => get(fontWeight),
+    (get, set, newFontWeight: number | null) => {
+        chrome.storage.local.set({[STORAGE_KEY_FONT_WEIGHT]: newFontWeight})
+            .then(() => {
+                set(fontWeight, newFontWeight ? newFontWeight : DEFAULT_FONT_WEIGHTS);
+            });
+    }
+)
+
+export const getCurrentDate = atom(
+    (get) => get(currentDate),
+    (get, set, updateDate: Date) => {
+        set(currentDate, updateDate);
+    }
+)
+
+export const isShowCurrentDate = atom(
+    (get) => get(showCurrentDate),
+    (get, set, update: boolean) => {
+        chrome.storage.local.set({[STORAGE_KEY_IS_SHOW_DATE]: update})
+            .then(() => {
+                set(showCurrentDate, update);
+            });
     }
 )

--- a/src/background/features/AdjusTimerWindow.tsx
+++ b/src/background/features/AdjusTimerWindow.tsx
@@ -3,8 +3,8 @@ import Timer from "./Timer/Timer";
 
 import "../../style.css";
 import Menu from "./Menu/Menu";
-import { ADJUSTIMER_WINDOW_PORT_PREFIX, ADJUSTIMER_WINDOW_TYPE_CHECK, ADJUSTIMER_WINDOW_TYPE_READY, ADJUSTIMER_WINDOW_UPDATE, ADJUSTIMER_WINDOW_UPDATE_AD, CONTENT_SCRIPT_TYPE_UPDATE, STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_TEXT_COLOR } from "../../constants";
-import { getBackgroundColor, getCurrentVideo, getPort, getTextColor } from "../atom";
+import { ADJUSTIMER_WINDOW_PORT_PREFIX, ADJUSTIMER_WINDOW_TYPE_CHECK, ADJUSTIMER_WINDOW_TYPE_READY, ADJUSTIMER_WINDOW_UPDATE, ADJUSTIMER_WINDOW_UPDATE_AD, CONTENT_SCRIPT_TYPE_UPDATE, STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_FONT_WEIGHT, STORAGE_KEY_FONTFAMILIY, STORAGE_KEY_IS_SHOW_DATE, STORAGE_KEY_SHADOW_COLOR, STORAGE_KEY_SHADOW_SIZE, STORAGE_KEY_TEXT_COLOR } from "../../constants";
+import { getBackgroundColor, getCurrentVideo, getCustomFont, getFontWeight, getPort, getShadowColor, getShadowSize, getTextColor, isShowCurrentDate } from "../atom";
 import { useAtom } from "jotai";
 
 let loopTimeoutId: number | null = null;
@@ -14,6 +14,11 @@ export const AdjusTimerWindow = (): ReactElement => {
     const [ port, setPort ] = useAtom(getPort);
     const [ backgroundColor, setBackgroundColor ] = useAtom(getBackgroundColor);
     const [ textColor, setTextColor ] = useAtom(getTextColor);
+    const [ customFont, setCustomFont] = useAtom(getCustomFont);
+    const [shadowSize, setShadowSize] = useAtom(getShadowSize);
+    const [shadowColor, setShadowColor] = useAtom(getShadowColor);
+    const [ fontWeight, setFontWeight ] = useAtom(getFontWeight);
+    const [ showCurrentDate, setShowCurrentDate ] = useAtom(isShowCurrentDate);
 
     /**
      * service workerとのport接続
@@ -45,9 +50,15 @@ export const AdjusTimerWindow = (): ReactElement => {
 
     useEffect(() => {
         // カラーピッカーの情報を取得
-        chrome.storage.local.get([STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_TEXT_COLOR], (value) => {
+        // フォントの情報を取得
+        chrome.storage.local.get([STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_TEXT_COLOR, STORAGE_KEY_FONTFAMILIY, STORAGE_KEY_SHADOW_SIZE, STORAGE_KEY_SHADOW_COLOR, STORAGE_KEY_IS_SHOW_DATE], (value) => {
             setBackgroundColor(value[STORAGE_KEY_BACKGROUND_COLOR]);
             setTextColor(value[STORAGE_KEY_TEXT_COLOR]);
+            setCustomFont(value[STORAGE_KEY_FONTFAMILIY]);
+            setShadowSize(value[STORAGE_KEY_SHADOW_SIZE]);
+            setShadowColor(value[STORAGE_KEY_SHADOW_COLOR]);
+            setFontWeight(value[STORAGE_KEY_FONT_WEIGHT]);
+            setShowCurrentDate(value[STORAGE_KEY_IS_SHOW_DATE]);
         });
     }, [])
 

--- a/src/background/features/AdjusTimerWindow.tsx
+++ b/src/background/features/AdjusTimerWindow.tsx
@@ -51,7 +51,7 @@ export const AdjusTimerWindow = (): ReactElement => {
     useEffect(() => {
         // カラーピッカーの情報を取得
         // フォントの情報を取得
-        chrome.storage.local.get([STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_TEXT_COLOR, STORAGE_KEY_FONTFAMILIY, STORAGE_KEY_SHADOW_SIZE, STORAGE_KEY_SHADOW_COLOR, STORAGE_KEY_IS_SHOW_DATE], (value) => {
+        chrome.storage.local.get([STORAGE_KEY_BACKGROUND_COLOR, STORAGE_KEY_TEXT_COLOR, STORAGE_KEY_FONTFAMILIY, STORAGE_KEY_SHADOW_SIZE, STORAGE_KEY_SHADOW_COLOR, STORAGE_KEY_FONT_WEIGHT, STORAGE_KEY_IS_SHOW_DATE], (value) => {
             setBackgroundColor(value[STORAGE_KEY_BACKGROUND_COLOR]);
             setTextColor(value[STORAGE_KEY_TEXT_COLOR]);
             setCustomFont(value[STORAGE_KEY_FONTFAMILIY]);

--- a/src/background/features/Menu/ColorPicker.tsx
+++ b/src/background/features/Menu/ColorPicker.tsx
@@ -1,11 +1,14 @@
 import { ReactElement } from "react";
 import { useAtom } from "jotai";
-import { getBackgroundColor, getTextColor } from "../../atom";
+import { getBackgroundColor, getFontWeight, getShadowColor, getShadowSize, getTextColor } from "../../atom";
 import { DEFAULT_BACKGROUND_COLOR, DEFAULT_TEXT_COLOR } from "../../../constants";
 
 const ColorPicker = (): ReactElement => {
     const [ backgroundColor, setBackgroundColor ] = useAtom(getBackgroundColor);
     const [ textColor, setTextColor ] = useAtom(getTextColor);
+    const [ shadowSize, setShadowSize] = useAtom(getShadowSize);
+    const [ shadowColor, setShadowColor] = useAtom(getShadowColor);
+    const [ fontWeight, setFontWeight] = useAtom(getFontWeight);
 
     const handleUpdateBackGroundColor = (backgroundColor: string) => {
         setBackgroundColor(backgroundColor);
@@ -14,10 +17,14 @@ const ColorPicker = (): ReactElement => {
     const handleUpdateTextColor = (textColor: string) => {
         setTextColor(textColor);
     }
+
+    const handleUpdateShadowSize = (shadowColor: string) => {
+        setShadowColor(shadowColor);
+    }
     return (
-        <div className="border p-3 text-center">
-            <div className="">
-                <span className="mr-2 text-xs align-middle">背景色の変更 ⇒</span>
+        <div>
+            <div className="mt-1">
+                <span className="mr-2 text-xs align-middle">背景色の変更：</span>
                 <input
                     role="button"
                     type="color"
@@ -26,15 +33,44 @@ const ColorPicker = (): ReactElement => {
                     onChange={(e) => handleUpdateBackGroundColor(e.target.value)}
                 />
             </div>
-            
-            <span className="mr-2 align-middle">文字色の変更 ⇒</span>
-            <input
-                role="button"
-                type="color"
-                className="w-7 align-middle cursor-pointer"
-                value={textColor ? textColor : DEFAULT_TEXT_COLOR}
-                onChange={(e) => handleUpdateTextColor(e.target.value)}
-            />
+            <div className="mt-1">
+                <span className="mr-2 align-middle">文字色の変更：</span>
+                <input
+                    role="button"
+                    type="color"
+                    className="w-7 align-middle cursor-pointer"
+                    value={textColor ? textColor : DEFAULT_TEXT_COLOR}
+                    onChange={(e) => handleUpdateTextColor(e.target.value)}
+                />
+                <span className="ml-5 align-middle">文字の太さ：{fontWeight}</span>
+                <input
+                    type="range"
+                    className="align-middle w-28"
+                    min={1}
+                    max={10}
+                    value={fontWeight}
+                    onChange={(e) => setFontWeight(Number(e.target.value))}
+                />
+            </div>
+            <div className="mt-1">
+                <span className="mr-2 align-middle">縁取色の変更：</span>
+                <input
+                    role="button"
+                    type="color"
+                    className="w-7 align-middle cursor-pointer"
+                    value={shadowColor ? shadowColor : DEFAULT_TEXT_COLOR}
+                    onChange={(e) => handleUpdateShadowSize(e.target.value)}
+                />
+                <span className="ml-5 align-middle">縁取の太さ：{shadowSize}</span>
+                <input
+                    type="range"
+                    className="align-middle w-28"
+                    min={0}
+                    max={10}
+                    value={shadowSize}
+                    onChange={(e) => setShadowSize(Number(e.target.value))}
+                />
+            </div>
         </div>
     )
 }

--- a/src/background/features/Menu/Help.tsx
+++ b/src/background/features/Menu/Help.tsx
@@ -1,8 +1,10 @@
 import imgUrl from "../../../../public/extension_32.png";
+import Title from "./Title";
 
 const Help = () => {
     return (
         <div className="p-3 bg-gray-100">
+            <Title />
             <div className="text-left mt-5">
                 <p className="text-xl"><img className="inline align-top" src={imgUrl} /># 使い方</p>
                 <hr />
@@ -13,7 +15,7 @@ const Help = () => {
                     <li>動画URLと一致しているかを確認する</li>
                     <li>色のパレット部分を選択し、UIを好みに合わせる</li>
                     <li>「情報を取得する」を押す</li>
-                    <li>うまく取得できない場合は、Q&amp;Aページを参考にしてください</li>
+                    <li>うまく取得できない場合は、<a href="https://patiopatimon.com/adjustimer/" target="_blank" className="text-red-800 font-bold underline underline-offset-4">使い方ページ</a>を参考にしてください</li>
                 </ul>
             </div>
             <div className="mt-3">
@@ -24,17 +26,17 @@ const Help = () => {
                         text-xs
                         text-white
                         rounded-lg
-                        bg-gray-600
+                        bg-violet-500
                         px-5 py-1.5
                         mt-1
                         transition-all
-                        hover:bg-rose-400
+                        hover:bg-violet-300
                         hover:ring-2
-                        hover:ring-rose-400
+                        hover:bg-violet-300
                         hover:ring-offset-2
                         inline
                 ">
-                    ▶使い方/Q&amp;Aページへ
+                    ▶要望/報告フォーム
                 </a>
             </div>
         </div>

--- a/src/background/features/Menu/Menu.tsx
+++ b/src/background/features/Menu/Menu.tsx
@@ -1,4 +1,3 @@
-import Title from "./Title";
 import NavigationItem from "./NavigationItem";
 import { ReactElement, useEffect, useState } from "react";
 import Footer from "../Footer/Footer";
@@ -42,7 +41,6 @@ const Menu = (): ReactElement => {
             <div className={"mt-auto accodion " + (isOpen ? "visible" : "hidden")}>
                 <div className="w-9/10 mb-3 text-center mx-auto">
                     <div className="overflow-hidden">
-                        <Title />
                         <div className="
                             flex
                             space-x-5

--- a/src/background/features/Menu/Title.tsx
+++ b/src/background/features/Menu/Title.tsx
@@ -14,7 +14,7 @@ const Title = (): ReactElement => {
     const openPipWindow = useAtomCallback(
         useCallback(async (get, set) => {
             const pw = await window.documentPictureInPicture?.requestWindow({
-                width: 700,
+                width: 800,
                 height: 350,
                 disallowReturnToOpener: false,
                 preferInitialWindowPlacement: false,
@@ -74,8 +74,9 @@ const Title = (): ReactElement => {
                 font-bold
                 mt-3
             ">
-                AdjusTimer(アジャスタイマー)
-                Ver. {manifest.version}
+                AdjusTimer
+                <br />
+                <span className="text-xl">Ver. {manifest.version}</span>
             </h1>
             {isSupported  ? (
                 <p className="
@@ -83,9 +84,9 @@ const Title = (): ReactElement => {
                         text-white
                         rounded-lg
                         bg-rose-500
-                        px-5 py-1.5
+                        px-5 py-1
                         mt-1
-                        w-1/2
+                        w-9/10
                         transition-all
                         duration-300
                         hover:bg-rose-400

--- a/src/background/features/Timer/Timer.tsx
+++ b/src/background/features/Timer/Timer.tsx
@@ -1,11 +1,25 @@
 import { useAtom } from "jotai";
-import { DEFAULT_BACKGROUND_COLOR, DEFAULT_TEXT_COLOR } from "../../../constants";
-import { getBackgroundColor, getCurrentVideo, getTextColor } from "../../atom";
+import { DEFAULT_BACKGROUND_COLOR, DEFAULT_TEXT_COLOR, generateTextShadow } from "../../../constants";
+import { getBackgroundColor, getCurrentDate, getCurrentVideo, getCustomFont, getFontWeight, getShadowColor, getShadowSize, getTextColor, isShowCurrentDate } from "../../atom";
+import { useEffect } from "react";
 
 const Timer = () => {
     const [ currentVideo, setCurrentVideo ] = useAtom(getCurrentVideo);
     const [ backgroundColor, setBackgroundColor ] = useAtom(getBackgroundColor);
     const [ textColor, setTextColor ] = useAtom(getTextColor);
+    const [ customFont, setCustomFont] = useAtom(getCustomFont);
+    const [ shadowSize, setShadowSize] = useAtom(getShadowSize);
+    const [ shadowColor, setShadowColor] = useAtom(getShadowColor);
+    const [ fontWeight, setFontWeight ] = useAtom(getFontWeight);
+    const [ currentDate, setCurrentDate ] = useAtom(getCurrentDate);
+    const [ showCurrentDate, setShowCurrentDate ] = useAtom(isShowCurrentDate);
+
+    useEffect(() => {
+        const timer = setInterval(() => {
+            setCurrentDate(new Date());
+        }, 1000); // 1秒ごとに更新
+        return () => clearInterval(timer);
+    }, [])
 
     return (
         <div className="
@@ -17,14 +31,13 @@ const Timer = () => {
             grow"
             style={{
                 backgroundColor: backgroundColor ? backgroundColor : DEFAULT_BACKGROUND_COLOR,
-                color: textColor ? textColor : DEFAULT_TEXT_COLOR
             }}
         >
             {currentVideo.isAdBreak && (
                 <div>
                     <span className="
                         py-1
-                        px-1.5
+                        px-3
                         inline-flex
                         items-center
                         gap-x-1
@@ -33,22 +46,48 @@ const Timer = () => {
                         bg-red-100
                         text-red-800
                         rounded-full
-                        dark:bg-red-500/10
-                        dark:text-red-500
                     ">
                         <svg className="shrink-0 size-3" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"></path>
                             <path d="M12 9v4"></path>
                             <path d="M12 17h.01"></path>
                         </svg>
-                        広告再生中 - 残り:＜{currentVideo.adBreakRemainTime}＞
+                        <span className="text-sm">広告再生中 - 残り : {currentVideo.adBreakRemainTime}</span>
                     </span>
                 </div>
             )}
 
-            <p className="text-4xl">{currentVideo.title}</p>
-            <p className="text-3xl">{currentVideo.subTitle}</p>
-            <p className="mt-10 text-6xl">{currentVideo.currentTime}</p>
+            <div
+                style={{
+                    color: textColor ? textColor : DEFAULT_TEXT_COLOR,
+                    fontFamily: customFont,
+                    fontWeight: fontWeight * 100,
+                    textShadow: generateTextShadow(shadowSize, shadowColor),
+                }}
+            >
+                <p className="text-4xl">{currentVideo.title}</p>
+                <p className="text-3xl">{currentVideo.subTitle}</p>
+
+                <div className="relative">
+                    <div className={`
+                        absolute
+                        left-0
+                        top-0
+                        pointer-events-none
+                        p-3
+                        max-w-[160px]
+                        rounded-md
+                        bg-gray-500/30
+                        ${showCurrentDate ? "" : "hidden"}
+                    `}>
+                        <p className="text-xl">LIVE</p>
+                        <p className="text-3xl">{currentDate.toLocaleTimeString("ja-JP", { hour12: false })}</p>
+                        <hr />
+                        <p>{currentDate.toLocaleDateString("ja-JP")}</p>
+                    </div>
+                    <p className="mt-5 text-6xl flex items-center justify-center h-25">{currentVideo.currentTime}</p>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,5 @@
 import browser from 'webextension-polyfill';
-import { ADJUSTIMER_WINDOW_SET_TAB_ID, ADJUSTIMER_WINDOW_TYPE_CLOSE, ADJUSTIMER_WINDOW_TYPE_READY, ADJUSTIMER_WINDOW_UPDATE, CONTENT_SCRIPT_TYPE_UPDATE, MODE_CREATE_WINDOW, REGEX_ADJUSTIMER_WINDOW_PORT } from '../constants';
+import { ADJUSTIMER_WINDOW_SET_TAB_ID, ADJUSTIMER_WINDOW_TYPE_CLOSE, ADJUSTIMER_WINDOW_TYPE_READY, ADJUSTIMER_WINDOW_UPDATE, ADJUSTIMER_WINDOW_UPDATE_AD, CONTENT_SCRIPT_TYPE_UPDATE, MODE_CREATE_WINDOW, REGEX_ADJUSTIMER_WINDOW_PORT } from '../constants';
 
 let vid = -1;
 let currentTabId: string | undefined;
@@ -112,6 +112,7 @@ const onMessageAdjusTimer = (message: any, sender: any, sendResponse: any) => {
             console.log(`Service Worker: update currentTabId (${currentTabId})`);
             break;
         case ADJUSTIMER_WINDOW_UPDATE:
+        case ADJUSTIMER_WINDOW_UPDATE_AD:
             if (currentTabId) {
                 // (service worker ⇒ Content-Script)で実行する
                 console.log(`Service Worker: update video to content script.`);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -32,7 +32,7 @@ chrome.contextMenus.onClicked.addListener(async (item, tab) => {
                 focused : true,
                 type : 'popup',
                 height : 940,
-                width : 1000
+                width : 800
             },
             (window: any) => {
                 // 新規作成した AdjusTimer を使い回せるようにするため、

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,7 @@ export const VIDEO_NAME_AMAZON_PRIME = 'AmazonPrime';
 export const VIDEO_NAME_YOUTUBE = 'Youtube';
 export const VIDEO_NAME_NICONICO = 'Niconico';
 export const VIDEO_NAME_TVER = 'Tver';
+export const VIDEO_NAME_NETFLIX = 'Netflix';
 export const URL_TYPE_NOT_FOUND: string = 'notFound';
 export const TITLE_NOT_FOUND = "動画の更新等をお試しください。";
 
@@ -46,6 +47,7 @@ export const REGEX_URL_AMAZON_PRIME = new RegExp("https://www.amazon.co.jp/gp/vi
 export const REGEX_URL_YOUTUBE = new RegExp("https://www.youtube.com/watch*");
 export const REGEX_URL_NICONICO = new RegExp("https://www.nicovideo.jp/watch/*");
 export const REGEX_URL_TVER = new RegExp("https://tver.jp/episodes/*");
+export const REGEX_URL_NETFLIX = new RegExp("https://www.netflix.com/watch/*");
 export const STORAGE_KEY_BACKGROUND_COLOR = "AdjusTimer_backgroundColor";
 export const STORAGE_KEY_TEXT_COLOR = "AdjusTimer_textColor";
 
@@ -61,6 +63,7 @@ export const isTargetUrl = (url: string | undefined) => {
         case REGEX_URL_YOUTUBE.test(url):
         case REGEX_URL_NICONICO.test(url):
         case REGEX_URL_TVER.test(url):
+        case REGEX_URL_NETFLIX.test(url):
             isSuccess = true;
             break;
         default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,7 @@ export const VIDEO_NAME_DANIME = 'dAnime';
 export const VIDEO_NAME_AMAZON_PRIME = 'AmazonPrime';
 export const VIDEO_NAME_YOUTUBE = 'Youtube';
 export const VIDEO_NAME_NICONICO = 'Niconico';
+export const VIDEO_NAME_TVER = 'Tver';
 export const URL_TYPE_NOT_FOUND: string = 'notFound';
 export const TITLE_NOT_FOUND = "動画の更新等をお試しください。";
 
@@ -44,7 +45,7 @@ export const REGEX_URL_DANIME = new RegExp("https://animestore.docomo.ne.jp/anim
 export const REGEX_URL_AMAZON_PRIME = new RegExp("https://www.amazon.co.jp/gp/video/*");
 export const REGEX_URL_YOUTUBE = new RegExp("https://www.youtube.com/watch*");
 export const REGEX_URL_NICONICO = new RegExp("https://www.nicovideo.jp/watch/*");
-
+export const REGEX_URL_TVER = new RegExp("https://tver.jp/episodes/*");
 export const STORAGE_KEY_BACKGROUND_COLOR = "AdjusTimer_backgroundColor";
 export const STORAGE_KEY_TEXT_COLOR = "AdjusTimer_textColor";
 
@@ -59,6 +60,7 @@ export const isTargetUrl = (url: string | undefined) => {
         case REGEX_URL_AMAZON_PRIME.test(url):
         case REGEX_URL_YOUTUBE.test(url):
         case REGEX_URL_NICONICO.test(url):
+        case REGEX_URL_TVER.test(url):
             isSuccess = true;
             break;
         default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,6 @@ export interface VideoState {
 export interface updateVideoPayload {
     currentLocation: Location,
     currentTime: number | undefined,
-    isAdBreak: boolean,
-    adBreakRemainTime: string,
 }
 
 export class TabInfo {
@@ -28,11 +26,13 @@ export const ADJUSTIMER_WINDOW_TYPE_READY = "ready_adjustimer";
 export const ADJUSTIMER_WINDOW_TYPE_CLOSE = "close_adjustimer";
 export const ADJUSTIMER_WINDOW_SET_TAB_ID = "set_tab_id_adjustimer";
 export const ADJUSTIMER_WINDOW_UPDATE = "update_adjustimer";
+export const ADJUSTIMER_WINDOW_UPDATE_AD = "update_adjustimer_ad";
 export const ADJUSTIMER_WINDOW_TYPE_CHECK = "check_service_worker";
 
 export const VIDEO_NAME_DANIME = 'dAnime';
 export const VIDEO_NAME_AMAZON_PRIME = 'AmazonPrime';
 export const VIDEO_NAME_YOUTUBE = 'Youtube';
+export const VIDEO_NAME_NICONICO = 'Niconico';
 export const URL_TYPE_NOT_FOUND: string = 'notFound';
 export const TITLE_NOT_FOUND = "動画の更新等をお試しください。";
 
@@ -43,6 +43,7 @@ export const MODE_UPDATE_TO_CONTENT_SCRIPT: string = 'MODE_UPDATE_TO_CONTENT_SCR
 export const REGEX_URL_DANIME = new RegExp("https://animestore.docomo.ne.jp/animestore/sc_d_pc=*");
 export const REGEX_URL_AMAZON_PRIME = new RegExp("https://www.amazon.co.jp/gp/video/*");
 export const REGEX_URL_YOUTUBE = new RegExp("https://www.youtube.com/watch*");
+export const REGEX_URL_NICONICO = new RegExp("https://www.nicovideo.jp/watch/*");
 
 export const STORAGE_KEY_BACKGROUND_COLOR = "AdjusTimer_backgroundColor";
 export const STORAGE_KEY_TEXT_COLOR = "AdjusTimer_textColor";
@@ -57,6 +58,7 @@ export const isTargetUrl = (url: string | undefined) => {
         case REGEX_URL_DANIME.test(url):
         case REGEX_URL_AMAZON_PRIME.test(url):
         case REGEX_URL_YOUTUBE.test(url):
+        case REGEX_URL_NICONICO.test(url):
             isSuccess = true;
             break;
         default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,9 +50,25 @@ export const REGEX_URL_TVER = new RegExp("https://tver.jp/episodes/*");
 export const REGEX_URL_NETFLIX = new RegExp("https://www.netflix.com/watch/*");
 export const STORAGE_KEY_BACKGROUND_COLOR = "AdjusTimer_backgroundColor";
 export const STORAGE_KEY_TEXT_COLOR = "AdjusTimer_textColor";
+export const STORAGE_KEY_FONTFAMILIY = "AdjusTimer_fontFamily";
+export const STORAGE_KEY_SHADOW_SIZE = "AdjusTimer_shadowSize";
+export const STORAGE_KEY_SHADOW_COLOR = "AdjusTimer_shadowColor";
+export const STORAGE_KEY_FONT_WEIGHT = "AdjusTimer_fontWeight";
+export const STORAGE_KEY_IS_SHOW_DATE = "AdjusTimer_isShowDate";
 
 export const DEFAULT_BACKGROUND_COLOR = "#e2e8f0";
 export const DEFAULT_TEXT_COLOR = "#000000";
+export const CUSTOM_FONTS = [
+    "Noto Sans",
+    "Montserrat",
+    "Orbitron",
+    "Share Tech Mono",
+    "Russo One",
+    "Fredoka",
+    "Oxanium"
+
+];
+export const DEFAULT_FONT_WEIGHTS = 5;
 
 export const isTargetUrl = (url: string | undefined) => {
     if (!url) return false;
@@ -102,4 +118,15 @@ export const timeStringToSeconds = (timeStr: string) => {
   } else {
     throw new Error("Invalid time format: " + timeStr);
   }
+}
+
+export const generateTextShadow = (size: number, color: string) => {
+    const shadows = [];
+    for (let x = -size; x <= size; x++) {
+        for (let y = -size; y <= size; y++) {
+        if (x === 0 && y === 0) continue;
+        shadows.push(`${x}px ${y}px 0 ${color}`);
+        }
+    }
+    return shadows.join(", ");
 }

--- a/src/content/atom.ts
+++ b/src/content/atom.ts
@@ -149,7 +149,7 @@ export const getVideo = atom(
                                     : "";
                 // 広告
                 const netflixAdTime = document.querySelector("[data-uia=ads-info-time]");
-                if (netflixAdTime) {
+                if (netflixAdTime && netflixAdTime.textContent) {
                     isAdBreak = true;
                     adBreakRemainTime = secondToTimeString(timeStringToSeconds(netflixAdTime.textContent));
                 }

--- a/src/content/atom.ts
+++ b/src/content/atom.ts
@@ -3,6 +3,7 @@ import {
     REGEX_URL_AMAZON_PRIME,
     REGEX_URL_DANIME,
     REGEX_URL_NICONICO,
+    REGEX_URL_TVER,
     REGEX_URL_YOUTUBE,
     secondToTimeString,
     timeStringToSeconds,
@@ -12,6 +13,7 @@ import {
     VIDEO_NAME_AMAZON_PRIME,
     VIDEO_NAME_DANIME,
     VIDEO_NAME_NICONICO,
+    VIDEO_NAME_TVER,
     VIDEO_NAME_YOUTUBE,
     VideoState
 } from "../constants";
@@ -114,6 +116,27 @@ export const getVideo = atom(
                 }
 
                 newVideo.pageType = VIDEO_NAME_NICONICO;
+                break;
+            case REGEX_URL_TVER.test(update.currentLocation.href):
+                targetVideoTitle = document.querySelector("[class^=titles_seriesTitle]")
+                                ? document.querySelector("[class^=titles_seriesTitle]")?.textContent
+                                : TITLE_NOT_FOUND;
+                targetVideoSubTitle = document.querySelector("[class^=titles_title]")
+                                    ? document.querySelector("[class^=titles_title]")?.textContent
+                                    : "";
+                // 広告
+                const tverAdVideos = document.querySelectorAll<HTMLVideoElement>("video[title='Advertisement']");
+                for (const ad of tverAdVideos) {
+                    if (!ad.paused && ad.duration) {
+                        adBreakRemainTime = secondToTimeString(ad.duration - ad.currentTime);
+                    }
+                }
+                if (document.querySelectorAll(".strp-ad-player div div[style='display: block;']").length > 0) {
+                    isAdBreak = true;
+                } else {
+                    isAdBreak = false;
+                }
+                newVideo.pageType = VIDEO_NAME_TVER;
                 break;
             default:
                 targetVideoTitle = TITLE_NOT_FOUND;

--- a/src/content/atom.ts
+++ b/src/content/atom.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import {
     REGEX_URL_AMAZON_PRIME,
     REGEX_URL_DANIME,
+    REGEX_URL_NETFLIX,
     REGEX_URL_NICONICO,
     REGEX_URL_TVER,
     REGEX_URL_YOUTUBE,
@@ -12,6 +13,7 @@ import {
     URL_TYPE_NOT_FOUND,
     VIDEO_NAME_AMAZON_PRIME,
     VIDEO_NAME_DANIME,
+    VIDEO_NAME_NETFLIX,
     VIDEO_NAME_NICONICO,
     VIDEO_NAME_TVER,
     VIDEO_NAME_YOUTUBE,
@@ -137,6 +139,26 @@ export const getVideo = atom(
                     isAdBreak = false;
                 }
                 newVideo.pageType = VIDEO_NAME_TVER;
+                break;
+            case REGEX_URL_NETFLIX.test(update.currentLocation.href):
+                targetVideoTitle = document.querySelector(".netflixTitle")
+                                ? document.querySelector(".netflixTitle")?.textContent
+                                : TITLE_NOT_FOUND;
+                targetVideoSubTitle = document.querySelector(".netflixSubTitle")
+                                    ? document.querySelector(".netflixSubTitle")?.textContent
+                                    : "";
+                // 広告
+                const netflixAdTime = document.querySelector("[data-uia=ads-info-time]");
+                if (netflixAdTime) {
+                    isAdBreak = true;
+                    adBreakRemainTime = secondToTimeString(timeStringToSeconds(netflixAdTime.textContent));
+                }
+                // NetflixはvideoのcurrentTimeで時間を図っていないため、内部オブジェクトから再生時間を取得する
+                const currentTimeNetflix = document.querySelector(".netflixCurrentTime");
+                if (currentTimeNetflix) {
+                    updateTime = Number(currentTimeNetflix.textContent);
+                }
+                newVideo.pageType = VIDEO_NAME_NETFLIX;
                 break;
             default:
                 targetVideoTitle = TITLE_NOT_FOUND;

--- a/src/content/features/VideoInfo.tsx
+++ b/src/content/features/VideoInfo.tsx
@@ -10,6 +10,7 @@ import {
     REGEX_URL_AMAZON_PRIME,
     REGEX_URL_DANIME,
     REGEX_URL_NICONICO,
+    REGEX_URL_TVER,
     REGEX_URL_YOUTUBE,
     VideoState,
 } from "../../constants";
@@ -36,6 +37,7 @@ const VideoInfo = (): ReactElement => {
             case REGEX_URL_DANIME.test(location.href):
             case REGEX_URL_YOUTUBE.test(location.href):
             case REGEX_URL_NICONICO.test(location.href):
+            case REGEX_URL_TVER.test(location.href):
                 targetVideo = document.querySelector("video");
                 break;
             case REGEX_URL_AMAZON_PRIME.test(location.href):
@@ -69,7 +71,6 @@ const VideoInfo = (): ReactElement => {
     }
     // headタグの変化でページ移動を検出
     const updateLocation = (): void => {
-        console.log("Content Script: change location.");
         setCurrentLocation(location);
         updateVideoElement();
     }
@@ -116,9 +117,14 @@ const VideoInfo = (): ReactElement => {
         console.log("Content script: update video Element.");
         if (videoElement) {
             console.log("Content script: start timeupdate.")
-            document.querySelector("video")?.removeEventListener('progress', updateVideo);
+            document.querySelectorAll("video")?.forEach((v) => {
+                v.removeEventListener('progress', updateVideo);
+            })
             videoElement.removeEventListener('timeupdate', updateVideo);
-            document.querySelector("video")?.addEventListener('progress', updateVideo);
+
+            document.querySelectorAll("video")?.forEach((v) => {
+                v.addEventListener('progress', updateVideo);
+            })
             videoElement.addEventListener('timeupdate', updateVideo);
         }
     }, [videoElement]);

--- a/src/content/features/VideoInfo.tsx
+++ b/src/content/features/VideoInfo.tsx
@@ -5,14 +5,12 @@ import {
     ADJUSTIMER_WINDOW_TYPE_CLOSE,
     ADJUSTIMER_WINDOW_TYPE_READY,
     ADJUSTIMER_WINDOW_UPDATE,
+    ADJUSTIMER_WINDOW_UPDATE_AD,
     CONTENT_SCRIPT_TYPE_UPDATE,
     REGEX_URL_AMAZON_PRIME,
     REGEX_URL_DANIME,
+    REGEX_URL_NICONICO,
     REGEX_URL_YOUTUBE,
-    secondToTimeString,
-    timeStringToSeconds,
-    VIDEO_NAME_AMAZON_PRIME,
-    VIDEO_NAME_YOUTUBE,
     VideoState,
 } from "../../constants";
 import { useMutationObserver } from "../hooks";
@@ -27,12 +25,30 @@ const VideoInfo = (): ReactElement => {
     const urlRef = useRef(location);
     const [ currentLocation, setCurrentLocation ] = useState<Location>(urlRef.current); // 現在のページ
 
-    // headタグの変化でページ移動を検出、変化があった場合に updateFlag を更新
-    const updateLocation = (): void => {
-        console.log("Content Script: change location.");
-        setCurrentLocation(location);
+    /**
+     * 現ページのvideo要素を取得する
+     * @param {Location} location 現在のlocation情報
+     * @param {HTMLVideoElement | null | undefined} targetVideo 取得できたvideo要素
+     */
+    const getVideoElement = (location: Location): HTMLVideoElement | null | undefined => {
+        let targetVideo: HTMLVideoElement | null | undefined;
+        switch(true) {
+            case REGEX_URL_DANIME.test(location.href):
+            case REGEX_URL_YOUTUBE.test(location.href):
+            case REGEX_URL_NICONICO.test(location.href):
+                targetVideo = document.querySelector("video");
+                break;
+            case REGEX_URL_AMAZON_PRIME.test(location.href):
+                const primeVideo = document.querySelector(".dv-player-fullscreen");
+                if (primeVideo) {
+                    targetVideo = primeVideo.querySelector("video");
+                }
+                break;
+            default:
+                break;
+        }
+        return targetVideo;
     }
-    useMutationObserver(document.head, updateLocation);
 
     /**
      *
@@ -41,7 +57,7 @@ const VideoInfo = (): ReactElement => {
      * ⇒ video の 更新を行う
      *
      */
-    useEffect(() => {
+    const updateVideoElement = (): void => {
         // 現在のページのvideo要素を取得しなおす
         const currentVideoElement = getVideoElement(currentLocation);
         if (currentVideoElement) {
@@ -50,7 +66,18 @@ const VideoInfo = (): ReactElement => {
             setVideoElement(currentVideoElement);
             updateVideo();
         }
-    }, [currentLocation, updateFlag]);
+    }
+    // headタグの変化でページ移動を検出
+    const updateLocation = (): void => {
+        console.log("Content Script: change location.");
+        setCurrentLocation(location);
+        updateVideoElement();
+    }
+    useMutationObserver(document.head, updateLocation);
+
+    useEffect(() => {
+        updateVideoElement();
+    }, [updateFlag]);
 
     /**
      *
@@ -61,50 +88,9 @@ const VideoInfo = (): ReactElement => {
     const updateVideo = (): void => {
         if (!isAdjusTimer) return;
 
-        let updateTime: number | undefined = 0;
-        let isAdBreak: boolean = false;
-        let adBreakRemainTime: string = "";
-
-        // 広告の有無、amazon primeの特殊処理などの分岐
-        switch(video.pageType) {
-            case VIDEO_NAME_AMAZON_PRIME:
-                // メモ: ウォッチパーティのように他の人と同期したい場合、一度currentTime合わせた後に、表示時間のずれた分をさらに再計算して再配置するしかなさそう
-                // Amazonは広告がない場合に、表示時間のDOMを取得して表示する
-                const adDom = document.querySelector(".atvwebplayersdk-ad-timer-remaining-time");
-                if (!adDom) {
-                    const primeVideo = document.getElementsByClassName("atvwebplayersdk-timeindicator-text")
-                    if (primeVideo.length > 0) {
-                        const playShowTime: string | null = document.getElementsByClassName("atvwebplayersdk-timeindicator-text")[0].textContent;
-                        if (playShowTime) {
-                            updateTime = timeStringToSeconds(playShowTime.split("/")[0].trim());
-                        }
-                    }
-                } else {
-                    adBreakRemainTime = adDom.textContent ? adDom.textContent : "";
-                    isAdBreak = true;
-                }
-                break;
-            case VIDEO_NAME_YOUTUBE:
-                if (document.querySelector(".video-ads")?.innerHTML) {
-                    const adVideo: HTMLVideoElement | null = document.querySelector("video")
-                    if (adVideo) {
-                        adBreakRemainTime = secondToTimeString(adVideo.duration - adVideo.currentTime);
-                    }
-                    isAdBreak = true;
-                }
-                updateTime = videoElement?.currentTime;
-                break;
-            default:
-                updateTime = videoElement?.currentTime;
-                break;
-
-        }
-
         setVideo({
             currentLocation: currentLocation,
-            currentTime: updateTime,
-            isAdBreak: isAdBreak,
-            adBreakRemainTime: adBreakRemainTime
+            currentTime: videoElement?.currentTime
         });
         const updateVideoState: VideoState = {
             title: video.title,
@@ -123,40 +109,19 @@ const VideoInfo = (): ReactElement => {
      *
      * 動画の対象 videoElement が変わった際に、時間の更新 timeupdate の eventListener 登録しなおす
      * addEventListener('timeupdate')
+     * 広告動画の判定でprogressを使う（ニコニコ対応）
      *
      */
       useEffect(() => {
         console.log("Content script: update video Element.");
         if (videoElement) {
             console.log("Content script: start timeupdate.")
+            document.querySelector("video")?.removeEventListener('progress', updateVideo);
             videoElement.removeEventListener('timeupdate', updateVideo);
+            document.querySelector("video")?.addEventListener('progress', updateVideo);
             videoElement.addEventListener('timeupdate', updateVideo);
         }
     }, [videoElement]);
-
-    /**
-     * 現ページのvideo要素を取得する
-     * @param {Location} location 現在のlocation情報
-     * @param {HTMLVideoElement | null | undefined} targetVideo 取得できたvideo要素
-     */
-    const getVideoElement = (location: Location): HTMLVideoElement | null | undefined => {
-        let targetVideo: HTMLVideoElement | null | undefined;
-        switch(true) {
-            case REGEX_URL_DANIME.test(location.href):
-            case REGEX_URL_YOUTUBE.test(location.href):
-                targetVideo = document.querySelector("video");
-                break;
-            case REGEX_URL_AMAZON_PRIME.test(location.href):
-                const primeVideo = document.querySelector(".dv-player-fullscreen");
-                if (primeVideo) {
-                    targetVideo = primeVideo.querySelector("video");
-                }
-                break;
-            default:
-                break;
-        }
-        return targetVideo;
-    }
 
     /**
      * content script ⇐ service workerから受信部を最初に定義
@@ -166,9 +131,7 @@ const VideoInfo = (): ReactElement => {
     useEffect(() => {
         setVideo({
             currentLocation: currentLocation,
-            currentTime: 0,
-            isAdBreak: false,
-            adBreakRemainTime: "0:00"
+            currentTime: 0
         });
         chrome.runtime.onMessage.addListener(onMessageServiceWorker);
         return () => {
@@ -187,12 +150,12 @@ const VideoInfo = (): ReactElement => {
 
     const onMessageServiceWorker = (message: any) => {
         // service workerからのaction別に処理する
-        console.log(`Content Script: receive service worker.Type: ${message.action}`);
         switch(message.action) {
             case ADJUSTIMER_WINDOW_TYPE_READY:
                 isAdjusTimer = true;
                 break;
             case ADJUSTIMER_WINDOW_UPDATE:
+            case ADJUSTIMER_WINDOW_UPDATE_AD:
                 isAdjusTimer = true;
                 // videoElementを更新させ、updateVideoを発火させる
                 setUpdateFlag((updateFlag) => !updateFlag);
@@ -203,6 +166,9 @@ const VideoInfo = (): ReactElement => {
             default:
                 break;
         }
+        // 広告時間の更新はログが出過ぎるので、ログ出力しない
+        if (message.action === ADJUSTIMER_WINDOW_UPDATE_AD) return;
+        console.log(`Content Script: receive service worker.Type: ${message.action}`);
     }
     return (
         <>

--- a/src/content/features/VideoInfo.tsx
+++ b/src/content/features/VideoInfo.tsx
@@ -9,6 +9,7 @@ import {
     CONTENT_SCRIPT_TYPE_UPDATE,
     REGEX_URL_AMAZON_PRIME,
     REGEX_URL_DANIME,
+    REGEX_URL_NETFLIX,
     REGEX_URL_NICONICO,
     REGEX_URL_TVER,
     REGEX_URL_YOUTUBE,
@@ -27,6 +28,26 @@ const VideoInfo = (): ReactElement => {
     const [ currentLocation, setCurrentLocation ] = useState<Location>(urlRef.current); // 現在のページ
 
     /**
+     * 指定したファイルの中身をscriptタグに追記する（jsの挿入に使う）
+     * @param {string} file 挿入したいファイルのURL
+     * @param {string} node appendChildで挿入するタグ名
+     */
+    const injectScript = (file: string, node: string) => {
+        const scripts = document.querySelectorAll("script");
+        const extensionScript = scripts[scripts.length - 1];
+        if (!extensionScript?.src.match("adjustimer-netflix-loader.js")) {
+            const th = document.getElementsByTagName(node)[0];
+            const s = document.createElement('script');
+            s.setAttribute('type', 'text/javascript');
+            s.setAttribute('src', file);
+            th.appendChild(s);
+        }
+    }
+    if (REGEX_URL_NETFLIX.test(location.href)) {
+        injectScript(chrome.runtime.getURL("adjustimer-netflix-loader.js"), "body");
+    }
+
+    /**
      * 現ページのvideo要素を取得する
      * @param {Location} location 現在のlocation情報
      * @param {HTMLVideoElement | null | undefined} targetVideo 取得できたvideo要素
@@ -38,6 +59,7 @@ const VideoInfo = (): ReactElement => {
             case REGEX_URL_YOUTUBE.test(location.href):
             case REGEX_URL_NICONICO.test(location.href):
             case REGEX_URL_TVER.test(location.href):
+            case REGEX_URL_NETFLIX.test(location.href):
                 targetVideo = document.querySelector("video");
                 break;
             case REGEX_URL_AMAZON_PRIME.test(location.href):

--- a/src/content/hooks.ts
+++ b/src/content/hooks.ts
@@ -6,7 +6,7 @@ import { useEffect } from "react";
  * @param {callback} callback 検知後に発火するcallback
  */
 export const useMutationObserver = (
-    elements: any,
+    elements: Element | null,
     callback: any,
     options = {
         attributes: true,


### PR DESCRIPTION
# 追加機能
- VideoInfo内で広告判定をするのは、変だったので、atomのset内で実施するように変更
- ニコニコ動画の広告がDOMの監視で判定できなかったため、video要素全体に対して、progressでもupdateをkickするように修正（他サイトで暴発しないことは確認済み）
- 広告中のDOM監視が汎用的にできないため、isAdBreak=true（広告中）は500msずつAdjusTimer側から更新用のport.postMesageを送る
- Netflixは広告再生終了後、currentTimeが初期化されてしまうため、video要素は使えない。そのためinjectScriptした先でwindowオブジェクトから再生時間を取得し、DOMに現在時間情報を表示させるようにした（これをquerySelectorでとる）

# UI修正
- [x] フォントを変更できる（再起動時前回の状態である）
- [x] フォントの太さを変更できる（再起動時前回の状態である）
- [x] フォントの縁取りができる（再起動時前回の状態である）
- [x] フォントの縁取り色を変更できる（再起動時前回の状態である）
- [x] タイマーの左に現在時刻を表示できる（再起動時前回の状態である）

# テスト

https://docs.google.com/document/d/187iUdAb-v-3n9MM7Ui497x9EgN3WMhDiQSpK4hBEUyc/edit?tab=t.0

 