### PR TITLE
Netflixで続きを見るやホームに戻ったりするとAdjusTimerが反応しなくなる

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "AdjusTimer",
     "description": "再生動画の再生時間を別ウィンドウで映す拡張",
-    "version": "3.4.3",
+    "version": "3.4.4",
     "content_scripts": [
       {
         "js": ["src/content/index.tsx"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1605,6 +1606,7 @@
       "version": "22.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
       "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1614,6 +1616,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1667,6 +1670,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
       "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.31.1",
         "@typescript-eslint/types": "8.31.1",
@@ -1871,6 +1875,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1989,6 +1994,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -2375,6 +2381,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3516,6 +3523,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3524,6 +3532,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -3788,6 +3797,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3842,6 +3852,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3938,6 +3949,7 @@
       "version": "6.3.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4024,6 +4036,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/public/adjustimer-netflix-loader.js
+++ b/public/adjustimer-netflix-loader.js
@@ -2,7 +2,6 @@ console.log("Content Script: inject script Netflix");
 let tabTitle = "";
 
 const setNetflixTitleAndTime = () => {
-  console.log("Content Script: find Netfilix title...");
   // タイトル取得
   const videoId = location.href.split("?")[0].split("/").slice(-1)[0];
   const currentTitle = window.netflix.appContext.state.playerApp.getState().videoPlayer.videoMetadata[videoId]?._video?._video?.title;
@@ -39,8 +38,8 @@ const setNetflixTitleAndTime = () => {
     if (document.querySelector(".netflixTitle")) {
       document.querySelector(".netflixTitle").textContent = adjusTimerTitle;
       document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
-      document.querySelector(".netflixSubTitle").textContent = adjusTimerSubTitle;
       document.querySelector(".netflixCurrentTime").textContent = currentTime;
+      document.querySelector(".netflixFullTitle").textContent = `${adjusTimerTitle} | ${adjusTimerSubTitle}`;
     } else {
       // DOMに反映
       const titleNameElement = document.createElement("p");
@@ -60,13 +59,70 @@ const setNetflixTitleAndTime = () => {
       currentTimeElement.className = "netflixCurrentTime";
       currentTimeElement.textContent = currentTime;
       document.body.appendChild(currentTimeElement);
+
+      const videoFullTitle = document.createElement("p");
+      videoFullTitle.style.display = "none";
+      videoFullTitle.className = "netflixFullTitle";
+      videoFullTitle.textContent = `${adjusTimerTitle} | ${adjusTimerSubTitle}`;
+      document.body.appendChild(videoFullTitle);
     }
   }
 }
 
-let checkVideoDOM = setInterval(() => {
-  if (document.querySelector("video")) {
-    document.querySelector("video").addEventListener("timeupdate", setNetflixTitleAndTime);
-    clearInterval(checkVideoDOM);
+
+let checkVideoDOM = null;
+let currentVideoElement = null;
+// SPAの移動の際、video要素のみが削除されるため、それを検知するためのMutationObserverを入れる
+const videoLifecycleObserver = new MutationObserver((mutations) => {
+  const videoElement = document.querySelector("video");
+  mutations.forEach(node => {
+    node.removedNodes.forEach(() => {
+      // watch-videoクラスはNetflixの動画プレイヤーのクラスで、これが削除されるときにトップページなどの動画再生ページ以外に遷移したと判断する
+      if (node.target.className === "watch-video") {
+            startCheckVideoPlayer();
+      }
+    })
+  });
+  if (!videoElement) {
+    if (currentVideoElement) {
+      currentVideoElement.removeEventListener("timeupdate", setNetflixTitleAndTime);
+      currentVideoElement = null;
+    }
+    return;
   }
-}, 500);
+
+  if (videoElement !== currentVideoElement) {
+    attachVideoListener(videoElement);
+  }
+});
+
+const startCheckVideoPlayer = () => {
+  const checkVideoPlayer = setInterval(() => {
+    const videoPlayer = document.querySelector(".watch-video");
+    const videoElement = videoPlayer ? videoPlayer.querySelector("video") : null;
+    if (videoPlayer && videoElement) {
+      attachVideoListener(videoElement);
+      // mutation observerでvideoPlayerの子要素の変化を監視する(video要素の監視)
+      videoLifecycleObserver.observe(videoPlayer, {
+        childList: true,
+        subtree: true,
+      });
+      clearInterval(checkVideoPlayer);
+    }
+  }, 500);
+}
+startCheckVideoPlayer();
+
+// video要素にイベントリスナーをつける関数
+const attachVideoListener = (videoElement) => {
+  if (!videoElement || currentVideoElement === videoElement) {
+    return;
+  }
+
+  if (currentVideoElement) {
+    currentVideoElement.removeEventListener("timeupdate", setNetflixTitleAndTime);
+  }
+
+  currentVideoElement = videoElement;
+  currentVideoElement.addEventListener("timeupdate", setNetflixTitleAndTime);
+};

--- a/public/adjustimer-netflix-loader.js
+++ b/public/adjustimer-netflix-loader.js
@@ -78,8 +78,8 @@ const videoLifecycleObserver = new MutationObserver((mutations) => {
   mutations.forEach(node => {
     node.removedNodes.forEach(() => {
       // watch-videoクラスはNetflixの動画プレイヤーのクラスで、これが削除されるときにトップページなどの動画再生ページ以外に遷移したと判断する
-      if (node.target.className === "watch-video") {
-            startCheckVideoPlayer();
+      if (node.target instanceof Element && node.target.classList.contains("watch-video")) {
+        startCheckVideoPlayer();
       }
     })
   });
@@ -97,17 +97,23 @@ const videoLifecycleObserver = new MutationObserver((mutations) => {
 });
 
 const startCheckVideoPlayer = () => {
-  const checkVideoPlayer = setInterval(() => {
+  if (checkVideoDOM) {
+    return;
+  }
+
+  checkVideoDOM = setInterval(() => {
     const videoPlayer = document.querySelector(".watch-video");
     const videoElement = videoPlayer ? videoPlayer.querySelector("video") : null;
     if (videoPlayer && videoElement) {
       attachVideoListener(videoElement);
       // mutation observerでvideoPlayerの子要素の変化を監視する(video要素の監視)
+      videoLifecycleObserver.disconnect();
       videoLifecycleObserver.observe(videoPlayer, {
         childList: true,
         subtree: true,
       });
-      clearInterval(checkVideoPlayer);
+      clearInterval(checkVideoDOM);
+      checkVideoDOM = null;
     }
   }, 500);
 }

--- a/src/content/atom.ts
+++ b/src/content/atom.ts
@@ -34,10 +34,12 @@ export const initialVideoState: VideoState = {
 
 export const currentUrl = atom<string>();
 export const videoAtom = atom<VideoState>(initialVideoState);
+export const updateLocationSignalAtom = atom<number>(0);
 
 export const getVideo = atom(
     (get) => get(videoAtom),
     (get, set, update: updateVideoPayload) => {
+        const prevVideo = get(videoAtom);
         let newVideo = get(videoAtom);
         // タイトルを取得する
         let targetVideoTitle;
@@ -166,6 +168,18 @@ export const getVideo = atom(
                 if (currentTimeNetflix) {
                     updateTime = Number(currentTimeNetflix.textContent);
                 }
+
+                /**
+                 * もしvideoAtom(更新前)とnewVideo(更新後)のタイトルとサブタイトルのどちらかが異なった場合
+                 * VideoInfoのupdateLocationを実行する（SPAによるURL変更でタイトルのみが変わることがあるため）
+                */
+                if (
+                    prevVideo.title !== targetVideoTitle ||
+                    prevVideo.subTitle !== targetVideoSubTitle
+                ) {
+                    set(updateLocationSignalAtom, get(updateLocationSignalAtom) + 1);
+                }
+
                 newVideo.pageType = VIDEO_NAME_NETFLIX;
                 // タブ変更はnetflixはpublic/adjustimer-netflix-loader.jsで行う
                 break;

--- a/src/content/features/VideoInfo.tsx
+++ b/src/content/features/VideoInfo.tsx
@@ -35,9 +35,8 @@ const VideoInfo = (): ReactElement => {
      * @param {string} node appendChildで挿入するタグ名
      */
     const injectScript = (file: string, node: string) => {
-        const scripts = document.querySelectorAll("script");
-        const extensionScript = scripts[scripts.length - 1];
-        if (!extensionScript?.src.match("adjustimer-netflix-loader.js")) {
+        const extensionScript = document.querySelector("script[src*=\'adjustimer-netflix-loader.js'\]");
+        if (!extensionScript) {
             const th = document.getElementsByTagName(node)[0];
             const s = document.createElement('script');
             s.setAttribute('type', 'text/javascript');

--- a/src/content/features/VideoInfo.tsx
+++ b/src/content/features/VideoInfo.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from "jotai";
 import { ReactElement, useEffect, useRef, useState } from "react";
-import { getVideo } from "../atom";
+import { getVideo, updateLocationSignalAtom } from "../atom";
 import {
     ADJUSTIMER_WINDOW_TYPE_CLOSE,
     ADJUSTIMER_WINDOW_TYPE_READY,
@@ -22,6 +22,7 @@ let isAdjusTimer = false;
 
 const VideoInfo = (): ReactElement => {
     const [ video, setVideo ] = useAtom(getVideo); // AdjusTimer側に送るvideo情報
+    const [ updateLocationSignal ] = useAtom(updateLocationSignalAtom);
     const [ videoElement, setVideoElement ] = useState<HTMLVideoElement>(); // 現在ウォッチしているvideo要素
 
     const [ updateFlag, setUpdateFlag ] = useState<boolean>(false); // 何かしらの更新をAdjusTimerから受け取った場合にスイッチ
@@ -43,9 +44,6 @@ const VideoInfo = (): ReactElement => {
             s.setAttribute('src', file);
             th.appendChild(s);
         }
-    }
-    if (REGEX_URL_NETFLIX.test(location.href)) {
-        injectScript(chrome.runtime.getURL("adjustimer-netflix-loader.js"), "body");
     }
 
     /**
@@ -93,12 +91,21 @@ const VideoInfo = (): ReactElement => {
             updateVideo();
         }
     }
-    // headタグの変化でページ移動を検出
     const updateLocation = (): void => {
         setCurrentLocation(location);
         updateVideoElement();
     }
+    // headタグの変化でページ移動を検出
     useMutationObserver(document.head, updateLocation);
+
+    // netflix対応（atom側でタイトルの変更があった際にupdateLocationSignalの変更を検知する）
+    useEffect(() => {
+        updateLocation();
+        updateVideoElement();
+        if (REGEX_URL_NETFLIX.test(location.href)) {
+            injectScript(chrome.runtime.getURL("adjustimer-netflix-loader.js"), "body");
+        }
+    }, [updateLocationSignal]);
 
     useEffect(() => {
         updateVideoElement();


### PR DESCRIPTION
observerの見直し
・トップページに戻るとvideo要素を持つ親watch-videoそのものが破壊される
・続きを見るを押すとwatch-video内のvideo要素だけが変更される